### PR TITLE
feat: Add an unified api to export all FBCache settings

### DIFF
--- a/src/para_attn/first_block_cache/diffusers_adapters/cogvideox.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/cogvideox.py
@@ -55,6 +55,10 @@ def apply_cache_on_pipe(
     downsample_factor=1,
     **kwargs,
 ):
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(
+        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        **kwargs,
+    )
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 
@@ -62,8 +66,7 @@ def apply_cache_on_pipe(
         def new_call(self, *args, **kwargs):
             with utils.cache_context(
                 utils.create_cache_context(
-                    residual_diff_threshold=residual_diff_threshold,
-                    downsample_factor=downsample_factor,
+                    **cache_kwargs,
                 )
             ):
                 return original_call(self, *args, **kwargs)

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -58,10 +58,10 @@ def apply_cache_on_pipe(
     pipe: DiffusionPipeline,
     *,
     shallow_patch: bool = False,
-    residual_diff_threshold=0.05,
-    downsample_factor=1,
     **kwargs,
 ):
+    # NOTE: Split kwargs into cache_kwargs and other_kwargs
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(**kwargs)
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 
@@ -69,8 +69,7 @@ def apply_cache_on_pipe(
         def new_call(self, *args, **kwargs):
             with utils.cache_context(
                 utils.create_cache_context(
-                    residual_diff_threshold=residual_diff_threshold,
-                    downsample_factor=downsample_factor,
+                    **cache_kwargs,
                 )
             ):
                 return original_call(self, *args, **kwargs)

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -64,6 +64,8 @@ def apply_cache_on_pipe(
 ):
     # NOTE: Split kwargs into cache_kwargs and other_kwargs
     cache_kwargs, kwargs = utils.collect_cache_kwargs(**kwargs)
+    # Update default residual_diff_threshold and downsample_factor
+    # specified for current pipeline
     cache_kwargs["residual_diff_threshold"] = residual_diff_threshold
     cache_kwargs["downsample_factor"] = downsample_factor
     if not getattr(pipe, "_is_cached", False):

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -58,10 +58,14 @@ def apply_cache_on_pipe(
     pipe: DiffusionPipeline,
     *,
     shallow_patch: bool = False,
+    residual_diff_threshold=0.05,
+    downsample_factor=1,
     **kwargs,
 ):
     # NOTE: Split kwargs into cache_kwargs and other_kwargs
     cache_kwargs, kwargs = utils.collect_cache_kwargs(**kwargs)
+    cache_kwargs["residual_diff_threshold"] = residual_diff_threshold
+    cache_kwargs["downsample_factor"] = downsample_factor
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -5,9 +5,6 @@ import torch
 from diffusers import DiffusionPipeline, FluxTransformer2DModel
 
 from para_attn.first_block_cache import utils
-from para_attn.logger import init_logger
-
-logger = init_logger(__name__)
 
 
 def apply_cache_on_transformer(
@@ -65,12 +62,11 @@ def apply_cache_on_pipe(
     downsample_factor=1,
     **kwargs,
 ):
-    # NOTE: Split kwargs into cache_kwargs and other_kwargs
-    cache_kwargs, kwargs = utils.collect_cache_kwargs(**kwargs)
-    # Update default settings for Flux pipeline
-    cache_kwargs["residual_diff_threshold"] = residual_diff_threshold
-    cache_kwargs["downsample_factor"] = downsample_factor
-    logger.debug(f"Cache kwargs: {cache_kwargs}, Other kwargs: {kwargs}")
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(
+        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        **kwargs,
+    )
+
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -5,6 +5,9 @@ import torch
 from diffusers import DiffusionPipeline, FluxTransformer2DModel
 
 from para_attn.first_block_cache import utils
+from para_attn.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def apply_cache_on_transformer(
@@ -64,10 +67,10 @@ def apply_cache_on_pipe(
 ):
     # NOTE: Split kwargs into cache_kwargs and other_kwargs
     cache_kwargs, kwargs = utils.collect_cache_kwargs(**kwargs)
-    # Update default residual_diff_threshold and downsample_factor
-    # specified for current pipeline
+    # Update default settings for Flux pipeline
     cache_kwargs["residual_diff_threshold"] = residual_diff_threshold
     cache_kwargs["downsample_factor"] = downsample_factor
+    logger.debug(f"Cache kwargs: {cache_kwargs}, Other kwargs: {kwargs}")
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -63,7 +63,7 @@ def apply_cache_on_pipe(
     **kwargs,
 ):
     cache_kwargs, kwargs = utils.collect_cache_kwargs(
-        {"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
         **kwargs,
     )
 

--- a/src/para_attn/first_block_cache/diffusers_adapters/flux.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/flux.py
@@ -63,7 +63,7 @@ def apply_cache_on_pipe(
     **kwargs,
 ):
     cache_kwargs, kwargs = utils.collect_cache_kwargs(
-        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        {"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
         **kwargs,
     )
 

--- a/src/para_attn/first_block_cache/diffusers_adapters/hunyuan_video.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/hunyuan_video.py
@@ -191,6 +191,10 @@ def apply_cache_on_pipe(
     downsample_factor=1,
     **kwargs,
 ):
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(
+        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        **kwargs,
+    )
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 
@@ -198,8 +202,7 @@ def apply_cache_on_pipe(
         def new_call(self, *args, **kwargs):
             with utils.cache_context(
                 utils.create_cache_context(
-                    residual_diff_threshold=residual_diff_threshold,
-                    downsample_factor=downsample_factor,
+                    **cache_kwargs,
                 )
             ):
                 return original_call(self, *args, **kwargs)

--- a/src/para_attn/first_block_cache/diffusers_adapters/mochi.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/mochi.py
@@ -55,6 +55,10 @@ def apply_cache_on_pipe(
     downsample_factor=1,
     **kwargs,
 ):
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(
+        default_attrs={"residual_diff_threshold": residual_diff_threshold, "downsample_factor": downsample_factor},
+        **kwargs,
+    )
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 
@@ -62,8 +66,7 @@ def apply_cache_on_pipe(
         def new_call(self, *args, **kwargs):
             with utils.cache_context(
                 utils.create_cache_context(
-                    residual_diff_threshold=residual_diff_threshold,
-                    downsample_factor=downsample_factor,
+                    **cache_kwargs,
                 )
             ):
                 return original_call(self, *args, **kwargs)

--- a/src/para_attn/first_block_cache/diffusers_adapters/wan.py
+++ b/src/para_attn/first_block_cache/diffusers_adapters/wan.py
@@ -59,21 +59,26 @@ def apply_cache_on_pipe(
     slg_end: float = 0.1,
     **kwargs,
 ):
+    cache_kwargs, kwargs = utils.collect_cache_kwargs(
+        default_attrs={
+            "residual_diff_threshold": residual_diff_threshold,
+            "downsample_factor": downsample_factor,
+            "enable_alter_cache": True,
+            "slg_layers": slg_layers,
+            "slg_start": slg_start,
+            "slg_end": slg_end,
+            "num_inference_steps": kwargs.get("num_inference_steps", 50),
+        },
+        **kwargs,
+    )
     if not getattr(pipe, "_is_cached", False):
         original_call = pipe.__class__.__call__
 
         @functools.wraps(original_call)
         def new_call(self, *args, **kwargs):
-            num_inference_steps = kwargs.get("num_inference_steps", 50)
             with utils.cache_context(
                 utils.create_cache_context(
-                    residual_diff_threshold=residual_diff_threshold,
-                    downsample_factor=downsample_factor,
-                    enable_alter_cache=True,
-                    slg_layers=slg_layers,
-                    slg_start=slg_start,
-                    slg_end=slg_end,
-                    num_inference_steps=num_inference_steps,
+                    **cache_kwargs,
                 )
             ):
                 return original_call(self, *args, **kwargs)

--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -6,7 +6,10 @@ from typing import Any, DefaultDict, Dict, List, Optional, Union
 import torch
 
 import para_attn.primitives as DP
+from para_attn.logger import init_logger
 from .taylorseer import TaylorSeer
+
+logger = init_logger(__name__)
 
 
 @dataclasses.dataclass
@@ -190,7 +193,7 @@ def is_in_warmup():
     return cache_context.is_in_warmup()
 
 
-_current_cache_context = None
+_current_cache_context: CacheContext = None
 
 
 def create_cache_context(*args, **kwargs):
@@ -204,6 +207,15 @@ def get_current_cache_context():
 def set_current_cache_context(cache_context=None):
     global _current_cache_context
     _current_cache_context = cache_context
+
+
+def collect_cache_kwargs(**kwargs):
+    # Split kwargs into cache_kwargs and other_kwargs
+    cache_attrs = dataclasses.fields(CacheContext)
+    cache_attrs = [attr for attr in cache_attrs if hasattr(CacheContext, attr.name)]
+    cache_kwargs = {attr.name: kwargs.pop(attr.name, getattr(CacheContext, attr.name)) for attr in cache_attrs}
+    logger.info(f"Collected FBCache kwargs: {cache_kwargs}")
+    return cache_kwargs, kwargs
 
 
 @contextlib.contextmanager

--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -214,7 +214,6 @@ def collect_cache_kwargs(**kwargs):
     cache_attrs = dataclasses.fields(CacheContext)
     cache_attrs = [attr for attr in cache_attrs if hasattr(CacheContext, attr.name)]
     cache_kwargs = {attr.name: kwargs.pop(attr.name, getattr(CacheContext, attr.name)) for attr in cache_attrs}
-    logger.info(f"Collected FBCache kwargs: {cache_kwargs}")  # once
     return cache_kwargs, kwargs
 
 

--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -214,7 +214,7 @@ def collect_cache_kwargs(**kwargs):
     cache_attrs = dataclasses.fields(CacheContext)
     cache_attrs = [attr for attr in cache_attrs if hasattr(CacheContext, attr.name)]
     cache_kwargs = {attr.name: kwargs.pop(attr.name, getattr(CacheContext, attr.name)) for attr in cache_attrs}
-    logger.info(f"Collected FBCache kwargs: {cache_kwargs}")
+    logger.info(f"Collected FBCache kwargs: {cache_kwargs}")  # once
     return cache_kwargs, kwargs
 
 

--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -209,11 +209,19 @@ def set_current_cache_context(cache_context=None):
     _current_cache_context = cache_context
 
 
-def collect_cache_kwargs(**kwargs):
+def collect_cache_kwargs(default_attrs: dict, **kwargs):
     # Split kwargs into cache_kwargs and other_kwargs
+    # default_attrs: specific settings for different pipelines
     cache_attrs = dataclasses.fields(CacheContext)
     cache_attrs = [attr for attr in cache_attrs if hasattr(CacheContext, attr.name)]
     cache_kwargs = {attr.name: kwargs.pop(attr.name, getattr(CacheContext, attr.name)) for attr in cache_attrs}
+
+    assert default_attrs is not None, "default_attrs must be set before"
+    for attr in cache_attrs:
+        if attr.name in default_attrs:
+            cache_kwargs[attr.name] = default_attrs[attr.name]
+
+    logger.info(f"Collected Cache kwargs: {cache_kwargs}")  # once
     return cache_kwargs, kwargs
 
 

--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -210,7 +210,7 @@ def set_current_cache_context(cache_context=None):
 
 
 def collect_cache_kwargs(default_attrs: dict, **kwargs):
-    # Split kwargs into cache_kwargs and other_kwargs
+    # NOTE: This API will split kwargs into cache_kwargs and other_kwargs
     # default_attrs: specific settings for different pipelines
     cache_attrs = dataclasses.fields(CacheContext)
     cache_attrs = [attr for attr in cache_attrs if hasattr(CacheContext, attr.name)]

--- a/src/para_attn/logger.py
+++ b/src/para_attn/logger.py
@@ -27,7 +27,7 @@ class NewLineFormatter(logging.Formatter):
         return msg
 
 
-_root_logger = logging.getLogger("xfuser")
+_root_logger = logging.getLogger("para_attn")
 _default_handler = None
 _default_file_handler = None
 _inference_log_file_handler = {}

--- a/src/para_attn/logger.py
+++ b/src/para_attn/logger.py
@@ -1,0 +1,94 @@
+# Adapted from
+# https://github.com/skypilot-org/skypilot/blob/86dc0f6283a335e4aa37b3c10716f90999f48ab6/sky/sky_logging.py
+"""Logging configuration."""
+import logging
+import os
+import sys
+
+_FORMAT = "%(levelname)s %(asctime)s [%(filename)s:%(lineno)d] %(message)s"
+_DATE_FORMAT = "%m-%d %H:%M:%S"
+
+_LOG_LEVEL = os.environ.get("LOG_LEVEL", "debug")
+_LOG_LEVEL = getattr(logging, _LOG_LEVEL.upper(), 0)
+_LOG_DIR = os.environ.get("LOG_DIR", None)
+
+
+class NewLineFormatter(logging.Formatter):
+    """Adds logging prefix to newlines to align multi-line messages."""
+
+    def __init__(self, fmt, datefmt=None):
+        logging.Formatter.__init__(self, fmt, datefmt)
+
+    def format(self, record):
+        msg = logging.Formatter.format(self, record)
+        if record.message != "":
+            parts = msg.split(record.message)
+            msg = msg.replace("\n", "\r\n" + parts[0])
+        return msg
+
+
+_root_logger = logging.getLogger("xfuser")
+_default_handler = None
+_default_file_handler = None
+_inference_log_file_handler = {}
+
+
+def _setup_logger():
+    _root_logger.setLevel(_LOG_LEVEL)
+    global _default_handler
+    global _default_file_handler
+    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
+
+    if _default_handler is None:
+        _default_handler = logging.StreamHandler(sys.stdout)
+        _default_handler.flush = sys.stdout.flush  # type: ignore
+        _default_handler.setLevel(_LOG_LEVEL)
+        _root_logger.addHandler(_default_handler)
+
+    if _default_file_handler is None and _LOG_DIR is not None:
+        if not os.path.exists(_LOG_DIR):
+            try:
+                os.makedirs(_LOG_DIR)
+            except OSError as e:
+                _root_logger.warn(f"Error creating directory {_LOG_DIR} : {e}")
+        _default_file_handler = logging.FileHandler(_LOG_DIR + "/default.log")
+        _default_file_handler.setLevel(_LOG_LEVEL)
+        _default_file_handler.setFormatter(fmt)
+        _root_logger.addHandler(_default_file_handler)
+
+    _default_handler.setFormatter(fmt)
+    # Setting this will avoid the message
+    # being propagated to the parent logger.
+    _root_logger.propagate = False
+
+
+# The logger is initialized when the module is imported.
+# This is thread-safe as the module is only imported once,
+# guaranteed by the Python GIL.
+_setup_logger()
+
+
+def init_logger(name: str):
+    pid = os.getpid()
+    # Use the same settings as above for root logger
+    logger = logging.getLogger(name)
+    logger.setLevel(_LOG_LEVEL)
+    logger.addHandler(_default_handler)
+    if _LOG_DIR is not None and pid is None:
+        logger.addHandler(_default_file_handler)
+    elif _LOG_DIR is not None:
+        if _inference_log_file_handler.get(pid, None) is not None:
+            logger.addHandler(_inference_log_file_handler[pid])
+        else:
+            if not os.path.exists(_LOG_DIR):
+                try:
+                    os.makedirs(_LOG_DIR)
+                except OSError as e:
+                    _root_logger.warn(f"Error creating directory {_LOG_DIR} : {e}")
+            _inference_log_file_handler[pid] = logging.FileHandler(_LOG_DIR + f"/process.{pid}.log")
+            _inference_log_file_handler[pid].setLevel(_LOG_LEVEL)
+            _inference_log_file_handler[pid].setFormatter(NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT))
+            _root_logger.addHandler(_inference_log_file_handler[pid])
+            logger.addHandler(_inference_log_file_handler[pid])
+    logger.propagate = False
+    return logger


### PR DESCRIPTION
I really like ParaAttention. It is very concise and easy to modify. This PR add an unified API that can split kwargs from `apply_cache_on_pipe` func into cache_kwargs and other_kwargs. Thus, users can set any scalar attrs of CacheContext w/o  changing the current apply_cache_on_pipe API. for example, your can easily pass `warmup_steps = 8` to apply_cache_on_pipe func and don't need to hardcode it in the source codes. 

```python
apply_cache_on_pipe(
      pipe,
      residual_diff_threshold=0.08,
      warmup_steps = 8,
)
```
logging:

```bash
INFO 05-10 17:42:40 [utils.py:224] Collected Cache kwargs: {
        'residual_diff_threshold': 0.08, 
        'alter_residual_diff_threshold': None, 
        'downsample_factor': 1, 
        'enable_alter_cache': False, 
        'num_inference_steps': -1, 
        'warmup_steps': 8, 
        'enable_taylorseer': False, 
        'slg_layers': None, 
        'slg_start': 0.0, 
        'slg_end': 0.1, 
        'taylorseer': None, 
        'alter_taylorseer': None, 
        'executed_steps': 0, 
        'is_alter_cache': True
}
```