### PR TITLE
fix FluxSingleTransformerBlock missing encoder_hidden_states when use Flux-Kontext

### DIFF
--- a/src/para_attn/first_block_cache/utils.py
+++ b/src/para_attn/first_block_cache/utils.py
@@ -405,12 +405,8 @@ class CachedTransformerBlocks(torch.nn.Module):
                     if not self.return_hidden_states_first:
                         hidden_states, encoder_hidden_states = encoder_hidden_states, hidden_states
             if self.single_transformer_blocks is not None:
-                hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
                 for block in self.single_transformer_blocks:
-                    hidden_states = block(hidden_states, *args, **kwargs)
-                encoder_hidden_states, hidden_states = hidden_states.split(
-                    [encoder_hidden_states.shape[1], hidden_states.shape[1] - encoder_hidden_states.shape[1]], dim=1
-                )
+                    encoder_hidden_states, hidden_states = block(hidden_states, encoder_hidden_states, *args, **kwargs)
         else:
             for i, encoder_block in enumerate(self.transformer_blocks[1:]):
                 if slg_should_skip_block(i + 1):


### PR DESCRIPTION
I met same issue https://github.com/chengzeyi/ParaAttention/issues/49

```
packages/diffusers/models/transformers/transformer_flux.py", line 733, in forward
    encoder_hidden_states, hidden_states = block(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/para_attn/first_block_cache/utils.py", line 382, in forward
    ) = self.call_remaining_transformer_blocks(hidden_states, encoder_hidden_states, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/para_attn/first_block_cache/utils.py", line 410, in call_remaining_transformer_blocks
    hidden_states = block(hidden_states, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
TypeError: FluxSingleTransformerBlock.forward() missing 1 required positional argument: 'encoder_hidden_states'
```

Flux-Kontext  only in the version v0.35.1 which `FluxSingleTransformerBlock.forward` has changed  like this
https://github.com/huggingface/diffusers/blob/0f252be0ed42006c125ef4429156cb13ae6c1d60/src/diffusers/models/transformers/transformer_flux.py#L380

```
    def forward(
        self,
        hidden_states: torch.Tensor,
        encoder_hidden_states: torch.Tensor,
        temb: torch.Tensor,
        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
        joint_attention_kwargs: Optional[Dict[str, Any]] = None,
    ) -> Tuple[torch.Tensor, torch.Tensor]:
        text_seq_len = encoder_hidden_states.shape[1]
        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)

        residual = hidden_states
        norm_hidden_states, gate = self.norm(hidden_states, emb=temb)
        mlp_hidden_states = self.act_mlp(self.proj_mlp(norm_hidden_states))
        joint_attention_kwargs = joint_attention_kwargs or {}
        attn_output = self.attn(
            hidden_states=norm_hidden_states,
            image_rotary_emb=image_rotary_emb,
            **joint_attention_kwargs,
        )

        hidden_states = torch.cat([attn_output, mlp_hidden_states], dim=2)
        gate = gate.unsqueeze(1)
        hidden_states = gate * self.proj_out(hidden_states)
        hidden_states = residual + hidden_states
        if hidden_states.dtype == torch.float16:
            hidden_states = hidden_states.clip(-65504, 65504)

        encoder_hidden_states, hidden_states = hidden_states[:, :text_seq_len], hidden_states[:, text_seq_len:]
        return encoder_hidden_states, hidden_states
```



