### PR TITLE
Parallelize Qwen-Image Inference on MultiGPU using Context Parallel 

### DIFF
--- a/parallel_examples/run_qwen.py
+++ b/parallel_examples/run_qwen.py
@@ -1,0 +1,80 @@
+import torch, time
+import torch.distributed as dist
+from diffusers import DiffusionPipeline
+
+model_name = "Qwen/Qwen-Image"
+
+
+dist.init_process_group()
+
+torch.cuda.set_device(dist.get_rank())
+
+pipe = DiffusionPipeline.from_pretrained(model_name,  torch_dtype=torch.bfloat16,).to("cuda")
+
+positive_magic = {
+    "en": "Ultra HD, 4K, cinematic composition.", # for english prompt,
+    "zh": "超清，4K，电影级构图" # for chinese prompt,
+}
+
+prompt = '''A coffee shop entrance features a chalkboard sign reading "Qwen Coffee 😊 $2 per cup," with a neon light beside it displaying "通义千问". Next to it hangs a poster showing a beautiful Chinese woman, and beneath the poster is written "π≈3.1415926-53589793-23846264-33832795-02384197". Ultra HD, 4K, cinematic composition'''
+
+negative_prompt = " " # using an empty string if you do not have specific concept to remove
+
+
+# Generate with different aspect ratios
+aspect_ratios = {
+    "1:1": (1328, 1328),
+    "16:9": (1664, 928),
+    "9:16": (928, 1664),
+    "4:3": (1472, 1140),
+    "3:4": (1140, 1472),
+    "3:2": (1584, 1056),
+    "2:3": (1056, 1584),
+}
+width, height = aspect_ratios["16:9"]
+
+
+
+from para_attn.context_parallel import init_context_parallel_mesh
+from para_attn.context_parallel.diffusers_adapters import parallelize_pipe
+from para_attn.parallel_vae.diffusers_adapters import parallelize_vae
+
+mesh = init_context_parallel_mesh(
+    pipe.device.type,
+    max_ring_dim_size=2,
+)
+parallelize_pipe(
+    pipe,
+    mesh=mesh,
+)
+parallelize_vae(pipe.vae, mesh=mesh._flatten())
+
+# from para_attn.first_block_cache.diffusers_adapters import apply_cache_on_pipe
+
+# apply_cache_on_pipe(pipe)
+
+# pipe.enable_model_cpu_offload(gpu_id=dist.get_rank())
+
+# torch._inductor.config.reorder_for_compute_comm_overlap = True
+# pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune-no-cudagraphs")
+st = time.time()
+
+image = pipe(
+    prompt=prompt + positive_magic["en"],
+    negative_prompt=negative_prompt,
+    width=width,
+    height=height,
+     num_inference_steps=50,
+
+
+    true_cfg_scale=4.0,
+    output_type="pil" if dist.get_rank() == 0 else "pt",
+    generator=torch.Generator(device="cuda").manual_seed(42)
+).images[0]
+
+print("Inference time: ", time.time()-st)
+if dist.get_rank() == 0:
+    print("Saving image to qwen.png")
+    image.save(f"qwen_{dist.get_world_size()}.png")
+
+dist.destroy_process_group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 # install with `pip install -r requirements.txt`, and make sure that CI does the same
 packaging
 torch
+diffusers==0.35.1
+transformers==4.55.0

--- a/src/para_attn/context_parallel/diffusers_adapters/__init__.py
+++ b/src/para_attn/context_parallel/diffusers_adapters/__init__.py
@@ -17,6 +17,8 @@ def parallelize_transformer(transformer, *args, **kwargs):
         adapter_name = "hunyuan_video"
     elif transformer_cls_name.startswith("Wan"):
         adapter_name = "wan"
+    elif transformer_cls_name.startswith("QwenImage"): #QwenImageTransformer2DModel
+        adapter_name = "qwenimage"
     else:
         raise ValueError(f"Unknown transformer class name: {transformer_cls_name}")
 
@@ -41,6 +43,8 @@ def parallelize_pipe(pipe: DiffusionPipeline, *args, **kwargs):
         adapter_name = "hunyuan_video"
     elif pipe_cls_name.startswith("Wan"):
         adapter_name = "wan"
+    elif pipe_cls_name.startswith("QwenImage"): #QwenImageTransformer2DModel
+        adapter_name = "qwenimage"
     else:
         raise ValueError(f"Unknown pipeline class name: {pipe_cls_name}")
 

--- a/src/para_attn/context_parallel/diffusers_adapters/qwenimage.py
+++ b/src/para_attn/context_parallel/diffusers_adapters/qwenimage.py
@@ -1,0 +1,144 @@
+import functools
+from typing import List, Optional, Union, Tuple, Dict, Any
+import torch.nn.functional as F
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+import torch.distributed as dist
+import torch
+from diffusers import DiffusionPipeline, QwenImageTransformer2DModel
+import para_attn.primitives as DP
+from para_attn.context_parallel import init_context_parallel_mesh
+from para_attn.para_attn_interface import UnifiedAttnMode
+
+
+def parallelize_transformer(transformer: QwenImageTransformer2DModel, *, mesh=None):
+    if getattr(transformer, "_is_parallelized", False):
+        return transformer
+
+    mesh = init_context_parallel_mesh(transformer.device.type, mesh=mesh)
+    batch_mesh = mesh["batch"]
+    seq_mesh = mesh["ring", "ulysses"]._flatten()
+    world_size = dist.get_world_size()
+
+
+    @functools.wraps(transformer.__class__.forward)
+    def new_forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_hidden_states_mask: Optional[torch.Tensor] = None,
+        *args,
+        timestep: torch.LongTensor = None,
+        img_shapes: Optional[List[Tuple[int, int, int]]] = None,
+        txt_seq_lens: Optional[List[int]] = None,
+        guidance: torch.Tensor = None, 
+        return_dict: bool = True,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        hidden_states = self.img_in(hidden_states)
+        timestep = timestep.to(hidden_states.dtype)
+        encoder_hidden_states = self.txt_norm(encoder_hidden_states)
+        encoder_hidden_states = self.txt_in(encoder_hidden_states)
+        if guidance is not None:
+            guidance = guidance.to(hidden_states.dtype) * 1000
+
+        temb = (
+            self.time_text_embed(timestep, hidden_states)
+            if guidance is None
+            else self.time_text_embed(timestep, guidance, hidden_states)
+        )
+        image_rotary_emb = self.pos_embed(img_shapes, txt_seq_lens, device=hidden_states.device)
+        temp1 = image_rotary_emb[0]
+        temp1 = DP.get_assigned_chunk(temp1, dim=0, group=seq_mesh)
+        temp2 = image_rotary_emb[1] 
+
+        remainder = image_rotary_emb[1].shape[0] % world_size
+        if remainder != 0:
+            pad_amount = world_size - remainder
+            temp2 = F.pad(temp2, (0, 0, 0, pad_amount))
+
+
+        temp2= DP.get_assigned_chunk(temp2 , dim=0, group=seq_mesh)
+        image_rotary_emb = (temp1,temp2)
+        remainder = encoder_hidden_states.shape[1] % world_size
+
+        if remainder != 0:
+            pad_amount = world_size - remainder
+            encoder_hidden_states = F.pad(encoder_hidden_states, (0, 0, 0, pad_amount))
+
+        remainder = encoder_hidden_states_mask.shape[1] % world_size
+        if remainder != 0:
+            pad_amount = world_size - remainder
+            encoder_hidden_states_mask = F.pad(encoder_hidden_states_mask, (0, pad_amount))
+
+
+
+
+        if isinstance(timestep, torch.Tensor) and timestep.ndim != 0 and timestep.shape[0] == hidden_states.shape[0]:
+            timestep = DP.get_assigned_chunk(timestep, dim=0, group=batch_mesh)
+        hidden_states = DP.get_assigned_chunk(hidden_states, dim=0, group=batch_mesh)
+        hidden_states = DP.get_assigned_chunk(hidden_states, dim=-2, group=seq_mesh)
+        encoder_hidden_states = DP.get_assigned_chunk(encoder_hidden_states, dim=0, group=batch_mesh)
+        encoder_hidden_states = DP.get_assigned_chunk(encoder_hidden_states, dim=-2, group=seq_mesh)
+
+        encoder_hidden_states_mask = DP.get_assigned_chunk(encoder_hidden_states_mask, dim=1, group=seq_mesh)
+
+
+
+        with UnifiedAttnMode(mesh):
+            for index_block, block in enumerate(self.transformer_blocks):
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_hidden_states_mask=encoder_hidden_states_mask,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=attention_kwargs,
+                )
+
+        hidden_states = DP.get_complete_tensor(hidden_states, dim=-2, group=seq_mesh)
+        hidden_states = DP.get_complete_tensor(hidden_states, dim=0, group=batch_mesh)
+        hidden_states = self.norm_out(hidden_states, temb)
+
+        output = self.proj_out(hidden_states)
+
+        # if USE_PEFT_BACKEND:
+        #     # remove `lora_scale` from each PEFT layer
+        #     unscale_lora_layers(self, lora_scale)
+
+        if not return_dict:
+            return (output,)
+
+        return Transformer2DModelOutput(sample=output)
+
+    transformer.forward = new_forward.__get__(transformer)
+
+    transformer._is_parallelized = True
+
+    return transformer
+
+
+def parallelize_pipe(pipe: DiffusionPipeline, *, shallow_patch: bool = False, **kwargs):
+    if not getattr(pipe, "_is_parallelized", False):
+        original_call = pipe.__class__.__call__
+
+        @functools.wraps(original_call)
+        def new_call(self, *args, generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None, **kwargs):
+            if generator is None and getattr(self, "_is_parallelized", False):
+                seed_t = torch.randint(0, torch.iinfo(torch.int64).max, [1], dtype=torch.int64, device=self.device)
+                seed_t = DP.get_complete_tensor(seed_t, dim=0)
+                seed_t = DP.get_assigned_chunk(seed_t, dim=0, idx=0)
+                seed = seed_t.item()
+                seed -= torch.iinfo(torch.int64).min
+                generator = torch.Generator(self.device).manual_seed(seed)
+            return original_call(self, *args, generator=generator, **kwargs)
+
+        new_call._is_parallelized = True
+
+        pipe.__class__.__call__ = new_call
+        pipe.__class__._is_parallelized = True
+
+    if not shallow_patch:
+        parallelize_transformer(pipe.transformer, **kwargs)
+
+    return pipe

--- a/src/para_attn/para_attn_interface.py
+++ b/src/para_attn/para_attn_interface.py
@@ -98,6 +98,7 @@ def ulysses_attn_func(
     scale=None,
     mesh=None,
     attn_func=None,
+    enable_gqa=False
 ):
     assert query.ndim == 4, "query must have 4 dimensions, got {}".format(query.ndim)
     assert key.ndim == 4, "key must have 4 dimensions, got {}".format(key.ndim)
@@ -113,7 +114,7 @@ def ulysses_attn_func(
     if attn_func is None:
         attn_func = F.scaled_dot_product_attention
 
-    out = attn_func(query, key, value, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+    out = attn_func(query, key, value, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal, scale=scale, enable_gqa=enable_gqa)
 
     out = _sdpa_output_all_to_all(out, mesh)
     return out
@@ -211,6 +212,7 @@ def ring_attn_func(
     *,
     scale=None,
     mesh=None,
+    enable_gqa=False
 ):
     pg = DP.get_group(mesh)
     world_size = DP.get_world_size(pg)
@@ -223,6 +225,7 @@ def ring_attn_func(
             dropout_p=dropout_p,
             is_causal=is_causal,
             scale=scale,
+            enable_gqa=enable_gqa
         )
 
     assert attn_mask is None, "attn_mask is not supported in ring_attn_func when world_size > 1"
@@ -248,6 +251,7 @@ def in_batch_attn_func(
     is_causal=False,
     *,
     scale=None,
+    enable_gqa=False
 ):
     assert query.ndim == 4, "query must have 4 dimensions, got {}".format(query.ndim)
     assert key.ndim == 4, "key must have 4 dimensions, got {}".format(key.ndim)
@@ -270,6 +274,7 @@ def in_batch_attn_func(
         dropout_p=dropout_p,
         is_causal=is_causal,
         scale=scale,
+        enable_gqa=enable_gqa
     )
 
     out = out.reshape(h, b, s_q, -1).permute(1, 0, 2, 3)

--- a/src/para_attn/parallel_vae/diffusers_adapters/__init__.py
+++ b/src/para_attn/parallel_vae/diffusers_adapters/__init__.py
@@ -11,6 +11,8 @@ def parallelize_vae(vae, *args, **kwargs) -> None:
         adapter_name = "autoencoder_kl_hunyuan_video"
     elif vae_cls_name == "AutoencoderKLWan":
         adapter_name = "autoencoder_kl_wan"
+    elif vae_cls_name == "AutoencoderKLQwenImage":
+        adapter_name = "autoencoder_kl_qwenimage"
     else:
         raise ValueError(f"Unknown vae class name: {vae_cls_name}")
 

--- a/src/para_attn/parallel_vae/diffusers_adapters/autoencoder_kl_qwenimage.py
+++ b/src/para_attn/parallel_vae/diffusers_adapters/autoencoder_kl_qwenimage.py
@@ -1,0 +1,213 @@
+import functools
+
+import torch
+import torch.distributed as dist
+from diffusers.models.autoencoders.vae import DecoderOutput
+from diffusers import AutoencoderKLQwenImage
+import para_attn.primitives as DP
+from para_attn.parallel_vae import init_parallel_vae_mesh
+
+
+def send_tensor(tensor, dst, group):
+    tensor = tensor.contiguous()
+    dist.send_object_list([tensor.shape], dst=dst, group=group)
+    dist.send(tensor, dst=dst, group=group)
+
+
+def recv_tensor(src, group, device=None, dtype=None):
+    objects = [None]
+    dist.recv_object_list(objects, src=src, group=group)
+    t = torch.empty(objects[0], device=device, dtype=dtype)
+    dist.recv(t, src=src, group=group)
+    return t
+
+
+def parallelize_vae(vae: AutoencoderKLQwenImage, *, mesh=None):
+    """Parallelize Qwen-Image VAE across multiple processes using mesh parallelism."""
+    mesh = init_parallel_vae_mesh(vae.device.type, mesh=mesh)
+
+    group = DP.get_group(mesh)
+    world_size = DP.get_world_size(group)
+    rank = DP.get_rank(mesh)
+
+    vae.enable_tiling()
+
+    @functools.wraps(vae.__class__.tiled_encode)
+    def new_tiled_encode(
+        self,
+        x: torch.Tensor,
+    ):
+        _, _, num_frames, height, width = x.shape
+        latent_height = height // self.spatial_compression_ratio
+        latent_width = width // self.spatial_compression_ratio
+
+        tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
+        tile_latent_stride_height = self.tile_sample_stride_height // self.spatial_compression_ratio
+        tile_latent_stride_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+
+        blend_height = tile_latent_min_height - tile_latent_stride_height
+        blend_width = tile_latent_min_width - tile_latent_stride_width
+
+        # Split x into overlapping tiles and encode them separately.
+        count = 0
+        rows = []
+        for i in range(0, height, self.tile_sample_stride_height):
+            row = []
+            for j in range(0, width, self.tile_sample_stride_width):
+                if count % world_size == rank:
+                    self.clear_cache()
+                    time = []
+                    frame_range = 1 + (num_frames - 1) // 4
+                    for k in range(frame_range):
+                        self._enc_conv_idx = [0]
+                        if k == 0:
+                            tile = x[:, :, :1, i : i + self.tile_sample_min_height, j : j + self.tile_sample_min_width]
+                        else:
+                            tile = x[
+                                :,
+                                :,
+                                1 + 4 * (k - 1) : 1 + 4 * k,
+                                i : i + self.tile_sample_min_height,
+                                j : j + self.tile_sample_min_width,
+                            ]
+                        tile = self.encoder(tile, feat_cache=self._enc_feat_map, feat_idx=self._enc_conv_idx)
+                        tile = self.quant_conv(tile)
+                        time.append(tile)
+                    tile_result = torch.cat(time, dim=2)
+                else:
+                    tile_result = None
+                row.append(tile_result)
+                count += 1
+            rows.append(row)
+        self.clear_cache()
+
+        # Gather all tiles to rank 0
+        if rank == 0:
+            count = 0
+            for i in range(len(rows)):
+                for j in range(len(rows[i])):
+                    if count % world_size != rank:
+                        rows[i][j] = recv_tensor(count % world_size, group, device=x.device, dtype=x.dtype)
+                    count += 1
+        else:
+            for i in range(len(rows)):
+                for j in range(len(rows[i])):
+                    tile = rows[i][j]
+                    if tile is not None:
+                        send_tensor(tile, 0, group)
+
+        # Blend tiles on rank 0
+        if rank == 0:
+            result_rows = []
+            for i, row in enumerate(rows):
+                result_row = []
+                for j, tile in enumerate(row):
+                    # blend the above tile and the left tile
+                    # to the current tile and add the current tile to the result row
+                    if i > 0:
+                        tile = self.blend_v(rows[i - 1][j], tile, blend_height)
+                    if j > 0:
+                        tile = self.blend_h(row[j - 1], tile, blend_width)
+                    result_row.append(tile[:, :, :, :tile_latent_stride_height, :tile_latent_stride_width])
+                result_rows.append(torch.cat(result_row, dim=-1))
+
+            enc = torch.cat(result_rows, dim=3)[:, :, :, :latent_height, :latent_width]
+        else:
+            enc = recv_tensor(rank - 1, group, device=x.device, dtype=x.dtype)
+        
+        # Propagate result through all ranks
+        if rank < world_size - 1:
+            send_tensor(enc, rank + 1, group)
+        
+        return enc
+
+    vae.tiled_encode = new_tiled_encode.__get__(vae)
+
+    @functools.wraps(vae.__class__.tiled_decode)
+    def new_tiled_decode(
+        self,
+        z: torch.Tensor,
+        return_dict: bool = True,
+    ):
+        _, _, num_frames, height, width = z.shape
+        sample_height = height * self.spatial_compression_ratio
+        sample_width = width * self.spatial_compression_ratio
+
+        tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
+        tile_latent_stride_height = self.tile_sample_stride_height // self.spatial_compression_ratio
+        tile_latent_stride_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+
+        blend_height = self.tile_sample_min_height - self.tile_sample_stride_height
+        blend_width = self.tile_sample_min_width - self.tile_sample_stride_width
+
+        # Split z into overlapping tiles and decode them separately.
+        count = 0
+        rows = []
+        for i in range(0, height, tile_latent_stride_height):
+            row = []
+            for j in range(0, width, tile_latent_stride_width):
+                if count % world_size == rank:
+                    self.clear_cache()
+                    time = []
+                    for k in range(num_frames):
+                        self._conv_idx = [0]
+                        tile = z[:, :, k : k + 1, i : i + tile_latent_min_height, j : j + tile_latent_min_width]
+                        tile = self.post_quant_conv(tile)
+                        decoded = self.decoder(tile, feat_cache=self._feat_map, feat_idx=self._conv_idx)
+                        time.append(decoded)
+                    decoded_result = torch.cat(time, dim=2)
+                else:
+                    decoded_result = None
+                row.append(decoded_result)
+                count += 1
+            rows.append(row)
+        self.clear_cache()
+
+        # Gather all tiles to rank 0
+        if rank == 0:
+            count = 0
+            for i in range(len(rows)):
+                for j in range(len(rows[i])):
+                    if count % world_size != rank:
+                        rows[i][j] = recv_tensor(count % world_size, group, device=z.device, dtype=z.dtype)
+                    count += 1
+        else:
+            for i in range(len(rows)):
+                for j in range(len(rows[i])):
+                    decoded = rows[i][j]
+                    if decoded is not None:
+                        send_tensor(decoded, 0, group)
+
+        # Blend tiles on rank 0
+        if rank == 0:
+            result_rows = []
+            for i, row in enumerate(rows):
+                result_row = []
+                for j, tile in enumerate(row):
+                    # blend the above tile and the left tile
+                    # to the current tile and add the current tile to the result row
+                    if i > 0:
+                        tile = self.blend_v(rows[i - 1][j], tile, blend_height)
+                    if j > 0:
+                        tile = self.blend_h(row[j - 1], tile, blend_width)
+                    result_row.append(tile[:, :, :, : self.tile_sample_stride_height, : self.tile_sample_stride_width])
+                result_rows.append(torch.cat(result_row, dim=-1))
+
+            dec = torch.cat(result_rows, dim=3)[:, :, :, :sample_height, :sample_width]
+        else:
+            dec = recv_tensor(rank - 1, group, device=z.device, dtype=z.dtype)
+        
+        # Propagate result through all ranks
+        if rank < world_size - 1:
+            send_tensor(dec, rank + 1, group)
+
+        if not return_dict:
+            return (dec,)
+        
+        return DecoderOutput(sample=dec)
+
+    vae.tiled_decode = new_tiled_decode.__get__(vae)
+
+    return vae


### PR DESCRIPTION
I used **padding** to make tensors divisible by world size. As a result, it attends to those paddings to slightly change image.

aspect ratio:   "16:9": (1664, 928)
num_inference_steps=50
Hardware: NVIDIA H100 80GB HBM3

_How to run?_
```
pip install -r requirements.txt
cd parallel_examples
torchrun --nproc-per-node=2 run_qwen.py
```

(Inference time on 1 GPU:  33.15 seconds)
(Inference time on 2 GPUs:  **24.38** seconds, **36% Boost!** 🚀) 

 _Image comparison:_

<img width="1664" height="928" alt="image" src="https://github.com/user-attachments/assets/34a8186c-adea-473f-9221-2574dc69e7a9" />
<img width="1664" height="928" alt="image" src="https://github.com/user-attachments/assets/0046666c-2f23-41a7-86dc-b51d564167cd" />




